### PR TITLE
Add "CherryPy for Enterprise" for Tidelift leads

### DIFF
--- a/css/tidelift.css
+++ b/css/tidelift.css
@@ -1,0 +1,25 @@
+.tidelift-link {
+	border-radius: 18px;
+	background-color: #626980;
+	box-sizing: border-box;
+	color: white;
+	display: flex;
+	top: 0px;
+	right: 0px;
+	position: absolute;
+	background-image: url('https://cdn2.hubspot.net/hubfs/4008838/website/logos/logos_for_download/Tidelift_shorthand-logo_for-dark.png');
+	background-repeat: no-repeat;
+	background-position: 10px;
+	background-size: 12px;
+	padding: 6px 12px 6px 28px;
+	text-decoration: none;
+}
+
+.tidelift-link:hover, .tidelift-link-inline:hover {
+	color: white;
+}
+
+a.tidelift-link:active {
+  position: absolute;
+  top: 0px;
+}

--- a/css/tidelift.css
+++ b/css/tidelift.css
@@ -20,6 +20,10 @@
 }
 
 a.tidelift-link:active {
-  position: absolute;
-  top: 0px;
+	position: absolute;
+	top: 0px;
+}
+
+.tidelift-highlight {
+	text-transform: uppercase;
 }

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
             <li><a href="https://github.com/cherrypy/cherrypy">Development</a></li>
           </ul>
         </nav>
-        <a class="tidelift-link" href="/tidelift">CherryPy for Enterprise</a>
+        <a class="tidelift-link" href="https://tidelift.com/subscription/pkg/pypi-cherrypy?utm_source=pypi-cherrypy&utm_medium=referral&utm_campaign=homepage">CherryPy for Enterprise</a>
       </header>
 
       <section class="site">

--- a/index.html
+++ b/index.html
@@ -7,12 +7,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>CherryPy — A Minimalist Python Web Framework</title>
     <link rel="stylesheet" href="css/main.css" />
+    <link rel="stylesheet" href="css/tidelift.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Convergence%7CFjord+One" />
     <link rel="icon" href="images/favicon.gif" />
   </head>
   <body>
     <img width="128" src="images/cherrypy.png" alt="" class="site" />
-    
+
     <div class="fix-o">
       <header class="site clear">
         <hgroup class="fix-o">
@@ -28,13 +29,14 @@
             <li><a href="https://github.com/cherrypy/cherrypy">Development</a></li>
           </ul>
         </nav>
+        <a class="tidelift-link" href="/tidelift">CherryPy for Enterprise</a>
       </header>
-      
+
       <section class="site">
         <header>
           <h2>CherryPy is as easy as…</h2>
         </header>
-        
+
 <pre class="prettyprint" id="python"><span class="kwd">import</span><span class="pln"> cherrypy
 
 </span><span class="kwd">class</span><span class="pln"> </span><span class="typ">HelloWorld</span><span class="pun">(</span><span class="kwd">object</span><span class="pun">):</span><span class="pln">

--- a/index.html
+++ b/index.html
@@ -72,6 +72,14 @@ cherrypy</span><span class="pun">.</span><span class="pln">quickstart</span><spa
       </section>
       <section class="site">
         <header>
+          <h2>For Enterprise</h2>
+        </header>
+        <div class="tidelift-highlight"><a href="https://tidelift.com/subscription/pkg/pypi-cherrypy?utm_source=pypi-cherrypy&utm_medium=referral&utm_campaign=homepage2">Available as part of the tidelift subscription</a></div>
+        <p>CherryPy and the maintainers of thousands of other packages are working with Tidelift to deliver one enterprise subscription that covers all of the open source you use.</p>
+        <p>If you want the flexibility of open source and the confidence of commercial-grade software, this is for you. <a href="https://tidelift.com/subscription/pkg/pypi-cherrypy?utm_source=pypi-cherrypy&utm_medium=referral&utm_campaign=homepage2">Learn more</a>.</p>
+      </section>
+      <section class="site">
+        <header>
           <h2>Online tests</h2>
         </header>
         <p>Each time we change our codebase, a test runs so you can see the results <a href="https://travis-ci.org/cherrypy/cherrypy" target="_blank">here</a>.</p>


### PR DESCRIPTION
This change updates the CherryPy web site with a banner to drive potential business clients (Enterprise) to Tidelift for commercial support through that platform.